### PR TITLE
Fix insane auto scroll behaviour when executing first add, add_to, delete command upon launch

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -55,6 +55,8 @@ public class ModelManager implements Model {
         this.filteredClubs = new FilteredList<>(this.addressBook.getClubList());
         this.filteredMemberships = new FilteredList<>(this.addressBook.getMembershipList());
 
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        updateFilteredClubList(PREDICATE_SHOW_ALL_CLUBS);
         updateFilteredMembershipList(PREDICATE_SHOW_ALL_MEMBERSHIP);
     }
 


### PR DESCRIPTION
#259 
Insanely time consuming to figure out this AB3-inherited architectural bug.

For commands which change multiple items in the list such as add_to, it will scroll to the last edited item.